### PR TITLE
Use instance method to configure setting

### DIFF
--- a/lib/kibana/sinatra/web.rb
+++ b/lib/kibana/sinatra/web.rb
@@ -15,11 +15,11 @@ module Kibana
         erb :config
       end
 
-      def self.elasticsearch_url
+      def elasticsearch_url
         "http://\"+window.location.hostname+\":9200"
       end
 
-      def self.kibana_index
+      def kibana_index
         "kibana-int"
       end
     end

--- a/lib/kibana/views/config.erb
+++ b/lib/kibana/views/config.erb
@@ -18,14 +18,14 @@ function (Settings) {
      * elasticsearch host
      * @type {String}
      */
-    elasticsearch: "<%= Kibana::Sinatra::Web.elasticsearch_url %>",
+    elasticsearch: "<%= elasticsearch_url %>",
 
     /**
      * The default ES index to use for storing Kibana specific object
      * such as stored dashboards
      * @type {String}
      */
-    kibana_index: "<%= Kibana::Sinatra::Web.kibana_index %>",
+    kibana_index: "<%= kibana_index %>",
 
     /**
      * Panel modules available. Panels will only be loaded when they are defined in the


### PR DESCRIPTION
This is useful to change ES server or index by request context like following example.

``` ruby
module Kibana::Sinatra
  class Web
    def elasticsearch_url
      case request.path
      when /foo/
        "http://foo.example.com:9200"
      when /bar/
        "http://bar.example.com:9200"
      else
        "http://localhost:9200"
      end
    end
  end
end
```
